### PR TITLE
Flytt Employee typer til en egen fil + Gå til 404 page hvis ansatt fra route ikke finnes

### DIFF
--- a/app/components/employeeCV.tsx
+++ b/app/components/employeeCV.tsx
@@ -1,8 +1,8 @@
 "use client";
 import React, { useEffect, useState } from "react";
-import { EmployeeCV } from "../function/Employees";
 import { ErrorBoundary } from "./error";
 import dynamic from "next/dynamic";
+import Error from "next/error";
 import { Loading } from "./home";
 import { useChatStore } from "../store";
 import { isMobileScreen } from "../utils";
@@ -10,6 +10,7 @@ import styles from "../components/home.module.scss";
 import specificStyles from "../components/employeeCv.module.scss";
 import Sidebar from "./sidebar";
 import CV from "./CV";
+import { EmployeeCVDetails } from "../salesGPT/types";
 
 const Settings = dynamic(async () => (await import("./settings")).Settings, {
   loading: () => <Loading noLogo />,
@@ -26,10 +27,10 @@ const useHasHydrated = () => {
 };
 
 type SummaryOfQualificationProps = {
-  employeeAlias: string;
+  employee: EmployeeCVDetails | undefined;
 };
 
-function _EmployeeCV({ employeeAlias }: SummaryOfQualificationProps) {
+function _EmployeeCV({ employee }: SummaryOfQualificationProps) {
   const config = useChatStore((state) => state.config);
 
   // Setting
@@ -42,10 +43,14 @@ function _EmployeeCV({ employeeAlias }: SummaryOfQualificationProps) {
   if (isLoading) {
     return <Loading />;
   }
+  if (!employee) {
+    return <Error statusCode={404} />;
+  }
 
   async function handleButtonClick(requirementText: string): Promise<void> {
     setIsLoading(true);
     const requirements = requirementText.split("\n").filter((s) => s.length);
+    const employeeAlias = employee?.email.split("@")[0];
     await fetch("/api/chewbacca/generateSummaryOfQualifications", {
       method: "POST",
       headers: {
@@ -85,6 +90,9 @@ function _EmployeeCV({ employeeAlias }: SummaryOfQualificationProps) {
           <Settings closeSettings={() => setOpenSettings(false)} />
         ) : (
           <>
+            <div>
+              <p>Konsulent: {employee.email.split("@")[0]}</p>
+            </div>
             <textarea
               className={specificStyles.RequirementInput}
               placeholder={
@@ -93,7 +101,6 @@ function _EmployeeCV({ employeeAlias }: SummaryOfQualificationProps) {
               value={requirementText}
               onChange={(event) => setRequirementText(event.target.value)}
             ></textarea>
-            <CV GPTResponse={employeeAlias} />
             <button onClick={async () => handleButtonClick(requirementText)}>
               Generer oppsummering av kvalifikasjoner
             </button>
@@ -105,14 +112,12 @@ function _EmployeeCV({ employeeAlias }: SummaryOfQualificationProps) {
   );
 }
 
-export default function EmployeeCV({
-  employeeAlias,
-}: SummaryOfQualificationProps) {
+export default function EmployeeCV({ employee }: SummaryOfQualificationProps) {
   return (
     <ErrorBoundary
       fallback={<p> Something went wrong with the EmployeeCV! </p>}
     >
-      <_EmployeeCV employeeAlias={employeeAlias} />
+      <_EmployeeCV employee={employee} />
     </ErrorBoundary>
   );
 }

--- a/app/components/employeeCV.tsx
+++ b/app/components/employeeCV.tsx
@@ -10,7 +10,7 @@ import styles from "../components/home.module.scss";
 import specificStyles from "../components/employeeCv.module.scss";
 import Sidebar from "./sidebar";
 import CV from "./CV";
-import { EmployeeCVDetails } from "../salesGPT/types";
+import { EmployeeItem } from "../salesGPT/types";
 
 const Settings = dynamic(async () => (await import("./settings")).Settings, {
   loading: () => <Loading noLogo />,
@@ -27,7 +27,7 @@ const useHasHydrated = () => {
 };
 
 type SummaryOfQualificationProps = {
-  employee: EmployeeCVDetails | undefined;
+  employee: EmployeeItem | undefined;
 };
 
 function _EmployeeCV({ employee }: SummaryOfQualificationProps) {
@@ -91,7 +91,7 @@ function _EmployeeCV({ employee }: SummaryOfQualificationProps) {
         ) : (
           <>
             <div>
-              <p>Konsulent: {employee.email.split("@")[0]}</p>
+              <p>Konsulent: {employee.name}</p>
             </div>
             <textarea
               className={specificStyles.RequirementInput}

--- a/app/components/employees.tsx
+++ b/app/components/employees.tsx
@@ -1,7 +1,6 @@
 import EmployeeCard from "./employeeCard";
 import styles from "./home.module.scss";
 import employeeStyles from "./employees.module.scss";
-import { EmployeeItemProp } from "../function/Employees";
 import { useChatStore } from "../store";
 import { isMobileScreen } from "../utils";
 import { useState } from "react";
@@ -9,6 +8,7 @@ import { IconButton } from "./button";
 import ChatIcon from "../icons/chat.svg";
 import SettingsIcon from "../icons/settings.svg";
 import Link from "next/link";
+import { EmployeeItemProp } from "../salesGPT/types";
 
 type EmployeesProps = {
   showSideBar?: (newState: boolean) => void;

--- a/app/components/salesGPT.tsx
+++ b/app/components/salesGPT.tsx
@@ -10,7 +10,7 @@ import styles from "../components/home.module.scss";
 import dynamic from "next/dynamic";
 import { Loading } from "./home";
 import { ErrorBoundary } from "./error";
-import { EmployeeItemProp } from "../function/Employees";
+import { EmployeeItemProp } from "../salesGPT/types";
 
 const Settings = dynamic(async () => (await import("./settings")).Settings, {
   loading: () => <Loading noLogo />,

--- a/app/function/Employees.ts
+++ b/app/function/Employees.ts
@@ -37,3 +37,20 @@ export async function getEmployeeCVData(employeeAlias: string, token: string) {
   const employeeCVData = await requestEmployeeCVData(employeeAlias, token);
   return employeeCVData;
 }
+
+async function requestEmployeeData(
+  employeeAlias: string,
+): Promise<EmployeeItem | undefined> {
+  const request = await fetch(
+    `${BASE_URL}/employees/${employeeAlias}?country=no`,
+  );
+  if (!request.ok) {
+    return undefined;
+  }
+  return (await request.json()) as EmployeeItem;
+}
+
+export async function getEmployeeData(employeeAlias: string) {
+  const employeeData = await requestEmployeeData(employeeAlias);
+  return employeeData;
+}

--- a/app/function/Employees.ts
+++ b/app/function/Employees.ts
@@ -1,70 +1,5 @@
+import { EmployeeCVDetails, EmployeeItem } from "../salesGPT/types";
 import { requestOpenai } from "./CallGptWithoutReactContext";
-
-export type EmployeeItem = {
-  email: string;
-  name: string;
-  telephone: string;
-  imageUrl: string;
-  officeName: string;
-  startDate: Date;
-};
-
-export type EmployeeItemProp = {
-  employees: EmployeeItem[];
-};
-
-type WorkExperience = {
-  id: string;
-  title: string;
-  description: string;
-  monthFrom: string;
-  yearFrom: string;
-  monthTo: string;
-  yearTo: string;
-};
-
-type Role = {
-  id: string;
-  title: string;
-  description: string;
-};
-
-type ProjectExperience = {
-  id: string;
-  title: string;
-  description: string;
-  monthFrom: string;
-  yearFrom: string;
-  monthTo: string;
-  yearTo: string;
-  roles: Role[];
-  competencies: string[];
-};
-
-type Presentation = {
-  id: string;
-  title: string;
-  description: string;
-  month: string;
-  year: string;
-};
-
-type Certification = {
-  id: string;
-  title: string;
-  description: string;
-  expiryDate: Date;
-  issuedMonth: string;
-  issuedYear: string;
-};
-
-export type EmployeeCV = {
-  email: string;
-  workExperiences: WorkExperience[];
-  projectExperiences: ProjectExperience[];
-  presentations: Presentation[];
-  certifications: Certification[];
-};
 
 const BASE_URL = "https://chewie-webapp-ld2ijhpvmb34c.azurewebsites.net";
 
@@ -95,7 +30,7 @@ async function requestEmployeeCVData(employeeAlias: string, token: string) {
   if (!request.ok) {
     return undefined;
   }
-  return (await request.json()) as EmployeeCV;
+  return (await request.json()) as EmployeeCVDetails;
 }
 
 export async function getEmployeeCVData(employeeAlias: string, token: string) {

--- a/app/salesGPT/[employeeAlias]/page.tsx
+++ b/app/salesGPT/[employeeAlias]/page.tsx
@@ -1,12 +1,10 @@
 import { redirect } from "next/navigation";
 import Error from "next/error";
-
 import { getServerSession } from "next-auth/next";
-
 import { authOptions } from "../../api/auth/auth-options";
 import EmployeeCV from "@/app/components/employeeCV";
 import { CustomSession } from "@/app/api/auth/[...nextauth]/typing";
-import { getEmployeeCVData } from "@/app/function/Employees";
+import { getEmployeeData } from "@/app/function/Employees";
 
 export default async function App({
   params,
@@ -17,10 +15,7 @@ export default async function App({
   if (!session) {
     return redirect("/api/auth/signin");
   }
-  const employee = await getEmployeeCVData(
-    params.employeeAlias,
-    session.access_token,
-  );
+  const employee = await getEmployeeData(params.employeeAlias);
 
   return <EmployeeCV employee={employee} />;
 }

--- a/app/salesGPT/[employeeAlias]/page.tsx
+++ b/app/salesGPT/[employeeAlias]/page.tsx
@@ -1,10 +1,12 @@
 import { redirect } from "next/navigation";
+import Error from "next/error";
 
 import { getServerSession } from "next-auth/next";
 
 import { authOptions } from "../../api/auth/auth-options";
 import EmployeeCV from "@/app/components/employeeCV";
 import { CustomSession } from "@/app/api/auth/[...nextauth]/typing";
+import { getEmployeeCVData } from "@/app/function/Employees";
 
 export default async function App({
   params,
@@ -15,5 +17,10 @@ export default async function App({
   if (!session) {
     return redirect("/api/auth/signin");
   }
-  return <EmployeeCV employeeAlias={params.employeeAlias} />;
+  const employee = await getEmployeeCVData(
+    params.employeeAlias,
+    session.access_token,
+  );
+
+  return <EmployeeCV employee={employee} />;
 }

--- a/app/salesGPT/[employeeAlias]/page.tsx
+++ b/app/salesGPT/[employeeAlias]/page.tsx
@@ -1,5 +1,4 @@
 import { redirect } from "next/navigation";
-import Error from "next/error";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "../../api/auth/auth-options";
 import EmployeeCV from "@/app/components/employeeCV";

--- a/app/salesGPT/types.ts
+++ b/app/salesGPT/types.ts
@@ -1,0 +1,65 @@
+export type EmployeeItem = {
+  email: string;
+  name: string;
+  telephone: string;
+  imageUrl: string;
+  officeName: string;
+  startDate: Date;
+};
+
+export type EmployeeItemProp = {
+  employees: EmployeeItem[];
+};
+
+type WorkExperience = {
+  id: string;
+  title: string;
+  description: string;
+  monthFrom: string;
+  yearFrom: string;
+  monthTo: string;
+  yearTo: string;
+};
+
+type Role = {
+  id: string;
+  title: string;
+  description: string;
+};
+
+type ProjectExperience = {
+  id: string;
+  title: string;
+  description: string;
+  monthFrom: string;
+  yearFrom: string;
+  monthTo: string;
+  yearTo: string;
+  roles: Role[];
+  competencies: string[];
+};
+
+type Presentation = {
+  id: string;
+  title: string;
+  description: string;
+  month: string;
+  year: string;
+};
+
+type Certification = {
+  id: string;
+  title: string;
+  description: string;
+  expiryDate: Date;
+  issuedMonth: string;
+  issuedYear: string;
+};
+
+export type EmployeeCVDetails = {
+  email: string;
+  workExperiences: WorkExperience[];
+  projectExperiences: ProjectExperience[];
+  presentations: Presentation[];
+  certifications: Certification[];
+};


### PR DESCRIPTION
- Istedenfor å få feilmelding først når man trykker på knappen på CV-siden så får man nå 404 når man prøver å gå inn på en route på en ansatt som ikke finnes, feks https://variant.rocks/salesGPT/ikkeenekteansatt . 

- Flyttet typer som er relevante kun for SalgsGPT til salesGPT/types.ts og ga nytt navn til EmployeeCV-typen som kræsjet med komponenten EmployeeCV